### PR TITLE
Add support for PyTables array supported types

### DIFF
--- a/mopet/mopet.py
+++ b/mopet/mopet.py
@@ -547,11 +547,10 @@ class Exploration:
         for array in group:
             if isinstance(array, tables.array.Array):
                 value = array.read()
-                if not isinstance(value, np.ndarray):
-                    value = np.array(value)
-                # convert 0-dim arrays to floats
-                if value.ndim == 0:
-                    value = np.float(value)
+                # unwrap 0-dim arrays
+                if type(value) is np.ndarray and value.ndim == 0:
+                    value = array.dtype.type(value)
+
                 key = array._v_name
                 return_dict[key] = value
         return return_dict

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("requirements.txt") as f:
 
 setuptools.setup(
     name="mopet",
-    version="0.1.4",
+    version="0.1.5",
     description="The mildly ominous parameter exploration toolkit",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
* Do not transform every non ndarray element to a ndarray
* Use pytables array type to transform 0 dim array to single element
* Write tests that cover supported data types

Resolves #5 